### PR TITLE
Fix space

### DIFF
--- a/plantUml9/overview.md
+++ b/plantUml9/overview.md
@@ -20,8 +20,8 @@ PlantUML source[^1]:
  * @plantUml example.svg
  * Alice -> Bob: Authentication Request
  * Alice <-- Bob: Authentication Response
- * 
-{@literal *}/
+ *
+ *}/
 ```
 
 This is rendered as:


### PR DESCRIPTION
In the overview page, there is a space too less.

![image](https://github.com/mnlipp/jdrupes-taglets/assets/1366654/6e45c9cb-63f4-460d-bd62-9709b4add762)

This PR tries to fix it. I think `{@literal *}` is not needed and the plugin works without (does it?).
