### PR TITLE
Check with Java 17 and 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,22 +1,21 @@
 name: Java CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
     strategy:
       matrix:
-        java-version: [ '11' ]
+        java-version: [ '11', '17', '20' ]
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install graphviz
         run: sudo apt-get install graphviz
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java-version }}
       - name: Build with Gradle


### PR DESCRIPTION
Java 17 and Java 20 are also maintained as of today. They should also be checked.

This PR also updates the actions used to their most recent versions and enables checking if an external contributor opens a pull request.

If `pull_request` is not enabled as trigger, the output on a PR is as follows:

![image](https://github.com/mnlipp/jdrupes-taglets/assets/1366654/487ece04-72ca-4922-8f95-5f97b63291d6)
