### PR TITLE
Fix markdown-lint issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+charset = utf-8
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{yml}]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,10 @@
 root = true
 
 [*]
-end_of_line = lf
-insert_final_newline = true
-indent_style = space
 charset = utf-8
-indent_size = 4
+insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{yml}]
+[*.{md,yml}]
 indent_size = 2
+indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 /.gradle/
 /build/
 /.classpath

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea/
+.vscode/
+!.vscode/extensions.json
 /.gradle/
 /build/
 /.classpath

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "davidanson.vscode-markdownlint",
+        "editorconfig.editorconfig"
+    ]
+}

--- a/plantUml9/overview.md
+++ b/plantUml9/overview.md
@@ -1,17 +1,17 @@
-A taglet that generates UML diagrams with 
+A taglet that generates UML diagrams with
 [PlantUML](http://plantuml.sourceforge.net/) for inclusion in the javadoc.
 
 <a href="https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.jdrupes.taglets%22%20AND%20a%3A%22plantuml-taglet%22"><img src="https://img.shields.io/maven-central/v/org.jdrupes.taglets/plantuml-taglet.svg"></a>
-  
-**Please note that starting with version 2.0.0 the taglet works with 
+
+**Please note that starting with version 2.0.0 the taglet works with
 the API introduced in Java 9. It has been tested with Java-11.**
 
 **Starting with version 3.0.0 the taglet requires Java-17.**
-  
-Simply use the `@plantUml` tag to generate the graphics file from the 
+
+Simply use the `@plantUml` tag to generate the graphics file from the
 PlantUML source[^1]:
 
-```
+```java
 /**
  * Description.
  *
@@ -26,25 +26,25 @@ PlantUML source[^1]:
 ```
 
 This is rendered as:
- 
----
- 
-Description.
- 
-![Example Diagram](org/jdrupes/taglets/plantUml/example.svg)
- 
-This package/class ...
- 
+
 ---
 
-[^1]: The PlantUML source for the example above is actually 
+Description.
+
+![Example Diagram](org/jdrupes/taglets/plantUml/example.svg)
+
+This package/class ...
+
+---
+
+[^1]: The PlantUML source for the example above is actually
     in the package description instead of the overview source file.
     Java-11 to Java-15 (at least) drop block tags from an overview file.
     (Used to worked in Java-8.) See the report in the
     [Java Bug Database](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8264274)
- 
-The usage of "`<`" and "`>`" in PlantUML make javadoc complain about 
-illegal HTML tokens. Of course, you could use "`&amp;lt;`" and "`&amp;gt;`" but 
+
+The usage of "`<`" and "`>`" in PlantUML make javadoc complain about
+illegal HTML tokens. Of course, you could use "`&amp;lt;`" and "`&amp;gt;`" but
 this reduces the readability of the UML descriptions and is therefore
 not supported (the taglet does *not* scan for these sequences and convert
 them). You could globally disable HTML checks with e.g. "`-Xdoclint:-html`"
@@ -53,7 +53,7 @@ when using PlantUML but this might prevent other problems from being detected.
 The preferred approach is to put the PlantUML source in comments as
 shown below.
 
-```
+```java
 /**
  * @plantUml package.svg
  * &lt;!--
@@ -64,72 +64,68 @@ shown below.
 ```
 
 The taglet removes the comment delimiters and uses the resulting content
-as PlantUML source. Of course, you also have to avoid all "`-->`" arrows in 
-your PlantUML description as this would terminate the HTML comment 
-prematurely. Luckily, this isn't too hard because you can always exchange 
+as PlantUML source. Of course, you also have to avoid all "`-->`" arrows in
+your PlantUML description as this would terminate the HTML comment
+prematurely. Luckily, this isn't too hard because you can always exchange
 the left and right side of such a relation.
- 
-It's also possible to use `@startuml` and `@enduml` instead of `@plantuml`, 
-which is the common usage pattern. `@startuml` is simply a synonym for 
+
+It's also possible to use `@startuml` and `@enduml` instead of `@plantuml`,
+which is the common usage pattern. `@startuml` is simply a synonym for
 `@plantUml` and `@enduml` will be ignored entirely. Use this for
-compatibility with other tools, like e.g. the 
+compatibility with other tools, like e.g. the
 [PlantUML Eclipse Plugin](http://plantuml.com/eclipse) or the
 [PlantUML IDEA Plugin](https://github.com/esteinberg/plantuml4idea).
- 
 
-Invoking
---------
+## Invoking
 
 ### Gradle
- 
+
 Configuring a taglet in the javadoc task is not explicitly shown in the
 [DSL Reference](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.javadoc.Javadoc.html).
-The required properties can be found in the 
-[standard otions](https://docs.gradle.org/current/javadoc/org/gradle/external/javadoc/StandardJavadocDocletOptions.html)
- 
+The required properties can be found in the
+[standard options](https://docs.gradle.org/current/javadoc/org/gradle/external/javadoc/StandardJavadocDocletOptions.html)
+
 Here's an example:
- 
-```gradle
+
+```groovy
 configurations {
     javadocTaglets
 }
- 
+
 dependencies {
     javadocTaglets "org.jdrupes.taglets:plantuml-taglet:<version>"
 }
- 
+
 javadoc {
- 
+
     options.tagletPath = configurations.javadocTaglets.files as List
     options.taglets = ["org.jdrupes.taglets.plantUml.Taglet"]
     ...
 }
 ```
- 
+
 The latest version available on maven central is shown in the badge at the
 beginning of this page.
- 
+
 ### Command line
- 
+
 Specify the taglet on JavaDoc's command line:
- 
-```
+
+```terminal
 javadoc -taglet org.jdrupes.taglets.plantUml.Taglet -tagletpath /path/to/plantuml-taglet.jar:/path/to/plantuml.jar
 ```
- 
+
 This could be simplified by providing a "fat jar", but I doubt that anybody would
 really use it.
- 
- 
+
 ### Maven
- 
+
 Still using this? Well, you're on your own...
- 
-Notes
------
+
+## Notes
 
 This taglet is released under the
 [GPL 3.0](http://www.gnu.org/licenses/gpl-3.0-standalone.html).
 
-The project's sources can be found on 
+The project's sources can be found on
 [GitHub](https://github.com/mnlipp/jdrupes-taglets).


### PR DESCRIPTION
Part of https://github.com/mnlipp/jdrupes-taglets/pull/6

- Add [editorconfig](https://editorconfig.org/) to ensure proper formatting
- (Manually) fix linting issues of `overview.md` by using [markdown-lint](https://github.com/DavidAnson/markdownlint#markdownlint)
- Add [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) and [editorconfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) recommendations for VS.Code to enable "proper" development setup when using VS.Code
- Ignore `.idea` folder (I use IntelliJ for the Java code)