### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,24 +1,29 @@
 name: Java CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     strategy:
       matrix:
         java-version: [ '17' ]
+      fail-fast: false
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Install graphviz
-        run: sudo apt-get install graphviz
+        run: sudo apt-get install -qy graphviz
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
       - name: Build with Gradle
         run: ./gradlew build apidocs
         env:


### PR DESCRIPTION
This PR updates the GitHub actions. And only the GitHub actions. No gradle, no other files touched.

---

Notes in relation to https://github.com/mnlipp/jdrupes-taglets/pull/10. Can safely be ignored. The following comments should have gone to #10 to avoid confusion. I keep it here, because there are comments in this PR referring to this discussion.

This PR **does not** add a build matrix for JDK 20 (which is the JDK before the next LTS JDK 21). Gradle 7.3 does not support JDK 20. See https://docs.gradle.org/current/userguide/compatibility.html and also demonstrated at https://github.com/koppor/jdrupes-taglets/actions/runs/6029209905.

JDK 17 has EOL in 3 years:

![image](https://github.com/mnlipp/jdrupes-taglets/assets/1366654/f2f3fde0-46e9-4e79-9ab7-79d4f9550a19)

Source: https://endoflife.date/java

Thus, it is OK for me to keep JDK 17 and an older gradle version. - Even though I would advise to work on an update now, but I know that relying on another dependency is hard.