### PR TITLE
Add build (and store) of testfiles/

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,3 +23,9 @@ jobs:
         run: ./gradlew build apidocs
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Generate test JavaDocs
+        run: ./gradlew testJavaDoc
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Test JavaDocs JDK ${{ matrix.java-version }}
+          path: plantUml9/build/test-javadocs

--- a/plantUml9/build.gradle
+++ b/plantUml9/build.gradle
@@ -1,18 +1,18 @@
 /*
  * JDrupes MDoclet
  * Copyright (C) 2021 Michael N. Lipp
- * 
- * This program is free software; you can redistribute it and/or modify it 
- * under the terms of the GNU Affero General Public License as published by 
- * the Free Software Foundation; either version 3 of the License, or 
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but 
+ * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
  * for more details.
  *
- * You should have received a copy of the GNU Affero General Public License along 
+ * You should have received a copy of the GNU Affero General Public License along
  * with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
@@ -62,14 +62,14 @@ jar {
         from { generatePomFileForMavenPublication }
         rename ".*", "pom.xml"
     }
-    
+
     manifest {
         inputs.property("gitDescriptor", { grgit.describe() })
-        
+
         // Set Git revision information in the manifests of built bundles
         attributes('Git-SHA': grgit.head().id)
     }
-    
+
     doFirst {
         manifest {
             attributes('Git-Descriptor': inputs.properties['gitDescriptor'])
@@ -80,11 +80,11 @@ jar {
 configurations {
     markdownDoclet
 }
- 
+
 dependencies {
     markdownDoclet "org.jdrupes.mdoclet:doclet:3.0.0"
 }
- 
+
 task apidocs(type: JavaExec) {
     dependsOn classes
     inputs.file "overview.md"
@@ -93,9 +93,9 @@ task apidocs(type: JavaExec) {
         '--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED']
     classpath sourceSets.main.compileClasspath
     classpath files(tasks.jar)
-    
+
     ext.destinationDir = "$projectDir/build/docs/javadoc"
-    
+
     main = 'jdk.javadoc.internal.tool.Main'
     args = ['-doctitle', 'PlantUML Taglet',
         '-use',
@@ -119,7 +119,7 @@ task apidocs(type: JavaExec) {
         '-Xdoclint:-html',
         '--add-exports=jdk.javadoc/jdk.javadoc.internal.doclets.formats.html=ALL-UNNAMED'
         ]
-    
+
     ignoreExitValue true
 }
 
@@ -182,7 +182,7 @@ if (project.hasProperty('signing.keyId')) {
 }
 
 publishing {
-    
+
     repositories {
         maven {
             name "snapshot"
@@ -201,7 +201,7 @@ publishing {
             }
         }
     }
-    
+
 }
 
 // Additional configuration of publishing
@@ -248,7 +248,7 @@ build.mustRunAfter "releaseTag"
 
 task stageOnOssrh {
     group = "publishing"
-    
+
     dependsOn "releaseTag"
     dependsOn "publishMavenPublicationToReleaseRepository"
 }

--- a/plantUml9/build.gradle
+++ b/plantUml9/build.gradle
@@ -123,6 +123,34 @@ task apidocs(type: JavaExec) {
     ignoreExitValue true
 }
 
+task testJavaDoc(type: JavaExec) {
+    dependsOn jar
+
+    jvmArgs = ['--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED',
+        '--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED']
+    classpath sourceSets.main.compileClasspath
+    classpath files(tasks.jar)
+
+    main = 'jdk.javadoc.internal.tool.Main'
+    args = ['-doctitle', 'test',
+        '-use',
+        '-linksource',
+        '-link', 'https://docs.oracle.com/en/java/javase/17/docs/api/',
+        '--add-exports', 'jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED',
+        '--add-exports', 'jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED',
+        '-tagletpath', files(tasks.jar).asType(List).join(pathSeparator),
+        '-taglet', 'org.jdrupes.taglets.plantUml.PlantUml',
+        '-taglet', 'org.jdrupes.taglets.plantUml.StartUml',
+        '-taglet', 'org.jdrupes.taglets.plantUml.EndUml',
+        '-d', 'build/test-javadocs',
+        '-sourcepath', 'testfiles/',
+        '-subpackages', 'test:testMore',
+        '--add-exports=jdk.javadoc/jdk.javadoc.internal.doclets.formats.html=ALL-UNNAMED'
+        ]
+
+    ignoreExitValue true
+}
+
 task docs (type: Copy) {
     from apidocs.destinationDir
     into '../../jdrupes-taglets.gh-pages/plantuml-taglet/javadoc/'

--- a/plantUml9/build.gradle
+++ b/plantUml9/build.gradle
@@ -138,7 +138,7 @@ task testJavaDoc(type: JavaExec) {
         '-link', 'https://docs.oracle.com/en/java/javase/17/docs/api/',
         '--add-exports', 'jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED',
         '--add-exports', 'jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED',
-        '-tagletpath', files(tasks.jar).asType(List).join(pathSeparator),
+        '-tagletpath', files(tasks.jar).asType(List).join(":"),
         '-taglet', 'org.jdrupes.taglets.plantUml.PlantUml',
         '-taglet', 'org.jdrupes.taglets.plantUml.StartUml',
         '-taglet', 'org.jdrupes.taglets.plantUml.EndUml',


### PR DESCRIPTION
For me, it is important to have an reproducible build AND to see the build results.

With this PR GitHub build the test javadocs and stores them as artifacts.

The action is prepared to output the artifacts separated by JDK:

![image](https://github.com/mnlipp/jdrupes-taglets/assets/1366654/301bf803-902b-409f-9bf9-4a7f820d5aed)

Note that `org.jdrupes.mdoclet.MDoclet` is not included to test this taglet only.
