### PR TITLE
Fix documentation

### DIFF
--- a/plantUml9/overview.md
+++ b/plantUml9/overview.md
@@ -89,18 +89,16 @@ Here's an example:
 
 ```groovy
 configurations {
-    javadocTaglets
+    taglets
 }
 
 dependencies {
-    javadocTaglets "org.jdrupes.taglets:plantuml-taglet:<version>"
+    taglets "org.jdrupes.taglets:plantuml-taglet:2.1.0"
 }
 
 javadoc {
-
-    options.tagletPath = configurations.javadocTaglets.files as List
-    options.taglets = ["org.jdrupes.taglets.plantUml.Taglet"]
-    ...
+    options.tagletPath = configurations.taglets.files.asType(List)
+    options.taglets = ["org.jdrupes.taglets.plantUml.PlantUml", "org.jdrupes.taglets.plantUml.StartUml", "org.jdrupes.taglets.plantUml.EndUml"
 }
 ```
 


### PR DESCRIPTION
This fixes the documentation. `org.jdrupes.taglets.plantUml.Taglet` does not exist, at least, I could not find it in the source code.

With the below changes, it works.

Note that, I

- renamed `javadocTaglets` to `taglets`, because the latter is shorter and feels more fluent. I assume in the context of a Java project the term `taglet` is precise enough
- pinned the version of `plantuml-taglet` to the latest release. Reason: In my experience, a minimal setup example should be copy-and-paste friendly. Users can update versions by themselves, but finding the latest release version sometimes takes time. By setting an explicit version, the time to get a first success is reduced.