### PR TITLE
Add support for `@plantuml`

### DIFF
--- a/plantUml9/build.gradle
+++ b/plantUml9/build.gradle
@@ -108,6 +108,7 @@ task apidocs(type: JavaExec) {
         '--disable-auto-highlight',
         '-tagletpath', files(tasks.jar).asType(List).join(":"),
         '-taglet', 'org.jdrupes.taglets.plantUml.PlantUml',
+        '-taglet', 'org.jdrupes.taglets.plantUml.PlantUmlMixedCase',
         '-taglet', 'org.jdrupes.taglets.plantUml.StartUml',
         '-taglet', 'org.jdrupes.taglets.plantUml.EndUml',
         '-overview', 'overview.md',

--- a/plantUml9/overview.md
+++ b/plantUml9/overview.md
@@ -6,7 +6,12 @@ A taglet that generates UML diagrams with
 **Please note that starting with version 2.0.0 the taglet works with
 the API introduced in Java 9. It has been tested with Java-11.**
 
-**Starting with version 3.0.0 the taglet requires Java-17.**
+## Changes of version 3.0.0
+
+- `@plantuml` is now completely lower case. In case you want to have mixed case, additionally use `PlantUmlMixedCase`.
+- Starting with version 3.0.0 the taglet requires Java-17.
+
+## Quickstart
 
 Simply use the `@plantUml` tag to generate the graphics file from the
 PlantUML source[^1]:
@@ -19,7 +24,7 @@ PlantUML source[^1]:
  *
  * This package/class ...
  *
- * @plantUml example.svg
+ * @plantuml example.svg
  * Alice -> Bob: Authentication Request
  * Alice <-- Bob: Authentication Response
  */
@@ -55,7 +60,7 @@ shown below.
 
 ```java
 /**
- * @plantUml package.svg
+ * @plantuml package.svg
  * &lt;!--
  * Bob <-- Alice: Authentication Request
  * Alice <-- Bob: Authentication Response
@@ -71,7 +76,7 @@ the left and right side of such a relation.
 
 It's also possible to use `@startuml` and `@enduml` instead of `@plantuml`,
 which is the common usage pattern. `@startuml` is simply a synonym for
-`@plantUml` and `@enduml` will be ignored entirely. Use this for
+`@plantuml` and `@enduml` will be ignored entirely. Use this for
 compatibility with other tools, like e.g. the
 [PlantUML Eclipse Plugin](http://plantuml.com/eclipse) or the
 [PlantUML IDEA Plugin](https://github.com/esteinberg/plantuml4idea).
@@ -98,7 +103,7 @@ dependencies {
 
 javadoc {
     options.tagletPath = configurations.taglets.files.asType(List)
-    options.taglets = ["org.jdrupes.taglets.plantUml.PlantUml", "org.jdrupes.taglets.plantUml.StartUml", "org.jdrupes.taglets.plantUml.EndUml"
+    options.taglets = ["org.jdrupes.taglets.plantUml.PlantUml", "org.jdrupes.taglets.plantUml.PlantUmlMixedCase", "org.jdrupes.taglets.plantUml.StartUml", "org.jdrupes.taglets.plantUml.EndUml"
 }
 ```
 

--- a/plantUml9/overview.md
+++ b/plantUml9/overview.md
@@ -89,18 +89,16 @@ Here's an example:
 
 ```groovy
 configurations {
-    javadocTaglets
+    taglets
 }
 
 dependencies {
-    javadocTaglets "org.jdrupes.taglets:plantuml-taglet:<version>"
+    taglets "org.jdrupes.taglets:plantuml-taglet:2.1.0"
 }
 
 javadoc {
-
-    options.tagletPath = configurations.javadocTaglets.files as List
-    options.taglets = ["org.jdrupes.taglets.plantUml.Taglet"]
-    ...
+    options.tagletPath = configurations.taglets.files.asType(List)
+    options.taglets = ["org.jdrupes.taglets.plantUml.PlantUml", "org.jdrupes.taglets.plantUml.StartUml", "org.jdrupes.taglets.plantUml.EndUml"
 }
 ```
 

--- a/plantUml9/src/org/jdrupes/taglets/plantUml/PlantUml.java
+++ b/plantUml9/src/org/jdrupes/taglets/plantUml/PlantUml.java
@@ -1,18 +1,18 @@
 /*
  * JDrupes MDoclet
  * Copyright (C) 2021 Michael N. Lipp
- * 
- * This program is free software; you can redistribute it and/or modify it 
- * under the terms of the GNU Affero General Public License as published by 
- * the Free Software Foundation; either version 3 of the License, or 
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but 
+ * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
  * for more details.
  *
- * You should have received a copy of the GNU Affero General Public License along 
+ * You should have received a copy of the GNU Affero General Public License along
  * with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
@@ -48,7 +48,7 @@ import net.sourceforge.plantuml.SourceStringReader;
 import net.sourceforge.plantuml.preproc.Defines;
 
 /**
- * A JDK11 doclet that generates UML diagrams from PlantUML 
+ * A JDK11 doclet that generates UML diagrams from PlantUML
  * specifications in the comment.
  */
 public class PlantUml implements Taglet {
@@ -68,7 +68,7 @@ public class PlantUml implements Taglet {
 
     @Override
     public String getName() {
-        return "plantUml";
+        return "plantuml";
     }
 
     @Override

--- a/plantUml9/src/org/jdrupes/taglets/plantUml/PlantUmlMixedCase.java
+++ b/plantUml9/src/org/jdrupes/taglets/plantUml/PlantUmlMixedCase.java
@@ -1,0 +1,25 @@
+/*
+ * JDrupes MDoclet
+ * Copyright (C) 2023 Michael N. Lipp and contributors
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+package org.jdrupes.taglets.plantUml;
+
+public class PlantUmlMixedCase extends PlantUml {
+    @Override
+    public String getName() {
+        return "plantUml";
+    }
+}

--- a/plantUml9/testfiles/test/TestLowerCasePlantUml.java
+++ b/plantUml9/testfiles/test/TestLowerCasePlantUml.java
@@ -1,0 +1,15 @@
+package test;
+
+/**
+ * Simple test file with a diagram in the class description.
+ *
+ * <img src="test-lowercase-plantuml.svg" alt="Picture">
+ *
+ * @plantuml test-lowercase-plantuml.svg
+ * Alice --> Bob: Authentication Request
+ * Alice <-- Bob: Authentication Response
+ */
+public class TestLowerCasePlantUml {
+	public static void main(String[] args) {
+	}
+}


### PR DESCRIPTION
`@startuml` is all lower case. I wonderes, why `@plantUml` was mixed case. Even the current master `overview.md` contains one all-lower-cased `@plantuml`:

https://github.com/mnlipp/jdrupes-taglets/blob/6f35d00fe49c2fe7a34b03ac99f07792512c754b/plantUml9/overview.md?plain=1#L72

Most JavaDoc tags I saw are lower cased. I am aware that there are some mixed case ones (I found https://www.tutorialspoint.com/java/java_documentation.htm as an example). Nevertheless, it was "feeling" more natural for me to have support for `@plantuml`.

Nevertheless, there should be backwards compatiblity. Therefore, the taglet `PlantUmlMixedCase` taglet is introduced. It offers `@plantUml` and redirects everything else to the class `PlantUml`, which handles the all-lower-case.

Note that this PR builds on the single commit of https://github.com/mnlipp/jdrupes-taglets/pull/13. I posted this PR nevertheless to have the idea communicated. In case #13 is merged, the diff of this PR will become smaller.