### PR TITLE
Add inline tag support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,3 +28,5 @@ jobs:
         run: ./gradlew build apidocs
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Test with Gradle
+        run: ./gradlew check

--- a/plantUml9/build.gradle
+++ b/plantUml9/build.gradle
@@ -9,7 +9,7 @@
  *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public 
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
  * License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
@@ -84,6 +84,30 @@ configurations {
 dependencies {
     markdownDoclet "org.jdrupes.mdoclet:doclet:3.1.0"
 }
+
+task testJavaDoc(type: JavaExec) {
+    dependsOn jar
+
+    jvmArgs = ['--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED',
+               '--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED']
+    classpath sourceSets.main.compileClasspath
+    classpath files(tasks.jar)
+
+    main = 'jdk.javadoc.internal.tool.Main'
+    args = ['-doctitle', 'test',
+            '-use',
+            '-linksource',
+            '-link', 'https://docs.oracle.com/en/java/javase/17/docs/api/',
+            '--add-exports', 'jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED',
+            '--add-exports', 'jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED',
+            '--add-exports=jdk.javadoc/jdk.javadoc.internal.doclets.formats.html=ALL-UNNAMED',
+            '-d', 'build/test-javadocs',
+            '-tagletpath', files(tasks.jar).asType(List).join(":"),
+            '-taglet', 'org.jdrupes.taglets.plantUml.PlantUml',
+            'testfiles/test/TestBlockFeature.java'
+    ]
+}
+check.dependsOn(testJavaDoc)
 
 task apidocs(type: JavaExec) {
     dependsOn classes

--- a/plantUml9/overview.md
+++ b/plantUml9/overview.md
@@ -6,10 +6,45 @@ A taglet that generates UML diagrams with
 **Please note that starting with version 2.0.0 the taglet works with
 the API introduced in Java 9. It has been tested with Java-11.**
 
-**Starting with version 3.0.0 the taglet requires Java-17.**
+## News of version 3.0.0
 
-Simply use the `@plantUml` tag to generate the graphics file from the
-PlantUML source[^1]:
+- One can use `{`<code>@plantUml ...</code>`}` to generate PlantUML diagrams and have HTML valid JavaDoc without any escapings.
+- Starting with version 3.0.0 the taglet requires Java-17.
+
+## Quick Start
+
+Simply use the `@plantUml` inline tag to generate the graphics file from the
+PlantUML source:
+
+```java
+/**
+ * Description.
+ *
+ * <img src="example.svg">
+ *
+ * This package/class ...
+ *
+ * {@plantUml example.svg
+ * Alice -> Bob: Authentication Request
+ * Alice <-- Bob: Authentication Response
+ * }
+ */
+```
+
+This is rendered as:
+
+---
+
+Description.
+
+![Example Diagram](org/jdrupes/taglets/plantUml/example.svg)
+
+This package/class ...
+
+## Using as block tag
+
+The taglet can be used as block tag to avoid the wrapping within `{`...`}` of
+a PlantUML source[^1]:
 
 ```java
 /**
@@ -25,25 +60,14 @@ PlantUML source[^1]:
  */
 ```
 
-This is rendered as:
-
----
-
-Description.
-
-![Example Diagram](org/jdrupes/taglets/plantUml/example.svg)
-
-This package/class ...
-
----
-
 [^1]: The PlantUML source for the example above is actually
     in the package description instead of the overview source file.
-    Java-11 to Java-15 (at least) drop block tags from an overview file.
-    (Used to worked in Java-8.) See the report in the
-    [Java Bug Database](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8264274)
+    Java-11 to Java-17 drop block tags from an overview file.
+    It used to worked in Java-8 and works again in Java-18.
+    See the report in the
+    [Java Bug Database](https://bugs.openjdk.org/browse/JDK-8264274?attachmentSortBy=fileName)
 
-The usage of "`<`" and "`>`" in PlantUML make javadoc complain about
+However, the usage of "`<`" and "`>`" in PlantUML makes javadoc complain about
 illegal HTML tokens. Of course, you could use "`&amp;lt;`" and "`&amp;gt;`" but
 this reduces the readability of the UML descriptions and is therefore
 not supported (the taglet does *not* scan for these sequences and convert
@@ -69,7 +93,9 @@ your PlantUML description as this would terminate the HTML comment
 prematurely. Luckily, this isn't too hard because you can always exchange
 the left and right side of such a relation.
 
-It's also possible to use `@startuml` and `@enduml` instead of `@plantUml`,
+## Using `@startuml` and `@enduml`
+
+It is also possible to use `@startuml` and `@enduml` instead of `@plantUml`,
 which is the common usage pattern. `@startuml` is simply a synonym for
 `@plantUml` and `@enduml` will be ignored entirely. Use this for
 compatibility with other tools, like e.g. the

--- a/plantUml9/src/org/jdrupes/taglets/plantUml/PlantUml.java
+++ b/plantUml9/src/org/jdrupes/taglets/plantUml/PlantUml.java
@@ -1,18 +1,18 @@
 /*
  * JDrupes MDoclet
  * Copyright (C) 2021 Michael N. Lipp
- * 
- * This program is free software; you can redistribute it and/or modify it 
- * under the terms of the GNU Affero General Public License as published by 
- * the Free Software Foundation; either version 3 of the License, or 
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but 
+ * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License 
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License
  * for more details.
  *
- * You should have received a copy of the GNU Affero General Public License along 
+ * You should have received a copy of the GNU Affero General Public License along
  * with this program; if not, see <http://www.gnu.org/licenses/>.
  */
 
@@ -48,7 +48,7 @@ import net.sourceforge.plantuml.SourceStringReader;
 import net.sourceforge.plantuml.preproc.Defines;
 
 /**
- * A JDK11 doclet that generates UML diagrams from PlantUML 
+ * A JDK11 doclet that generates UML diagrams from PlantUML
  * specifications in the comment.
  */
 public class PlantUml implements Taglet {
@@ -79,7 +79,12 @@ public class PlantUml implements Taglet {
 
     @Override
     public boolean isInlineTag() {
-        return false;
+        return true;
+    }
+
+    @Override
+    public boolean isBlockTag() {
+        return true;
     }
 
     @Override

--- a/plantUml9/testfiles/test/TestBlockFeature.java
+++ b/plantUml9/testfiles/test/TestBlockFeature.java
@@ -1,0 +1,20 @@
+package test;
+
+/**
+ * Test file with a diagram in the class description.
+ *
+ * <img src="TestBlockFeature.svg" alt="Picture">
+ *
+ * {@plantUml TestBlockFeature.svg
+ * Alice --> Bob: Authentication Request
+ * Alice <-- Bob: Authentication Response
+ * }
+ */
+public class TestBlockFeature {
+	/**
+	 * The main class
+	 * @param args Ignored
+	 */
+	public static void main(String[] args) {
+	}
+}


### PR DESCRIPTION
Background: All other PRs were the prepration of this PR.

## Overview

My aims are:

- Have the javadoc linter pass (in its default configuration). Main reason: Users should not be forced to adapt their build pipeline.
- Have the javadoc content "clean", without any hacks or HTML escapings
- Be consistent with the Java universe

Recently, I read about the new [JEP 413: Code Snippets in Java API Documentation](https://openjdk.org/jeps/413), which provide following example:

```java
/**
 * The following code shows how to use {@code Optional.isPresent}:
 * {@snippet :
 * if (v.isPresent()) {
 *     System.out.println("v: " + v.get());
 * }
 * }
 */
```

This PR ports this idea to this plugin:

```java
/**
 * Description.
 *
 * <img src="example.svg">
 *
 * This package/class ...
 *
 * {@plantUml example.svg
 * Alice -> Bob: Authentication Request
 * Alice <-- Bob: Authentication Response
 * }
 */
```

## CI Tests

I also added an automatic CI check, which checks if the `javadoc` command runs through. The results are **not** uploaded anywhere for checking (result of discussion at https://github.com/mnlipp/jdrupes-taglets/pull/12). They have to be checked on the local machine of the developer.

The implementation of the test is done via a gradle task. That gradle task is hooked into the `check` task of gradlle. That task is the general checking task of Gradle including JUnit tests, but other code style tests, too. 

## Documentation updates

The above solution fulfills all three aims. When thinking of advertising this plugin to other persons, I would like to tell them: Just write PlantUML as usual, wrap it in `@{plantUml ...}` and you are done. When they check the documentation, this feature should be the first one to read.

Therefore, I put this how to as first.

I split the documentation in smaller sections to enable reading by the quick readers. (In German: Dies adressiert die Zielgruppe mit dem inneren Antreiber "[sei schnell](https://www.mentor-app.de/blog/der-innere-antreiber-sei-schnell/)")

Finally, I updated the link to `JDK-826427` and the corresponding text: The issue was fixed in JDK-18 🎉 
